### PR TITLE
Update xcalib.c

### DIFF
--- a/xcalib.c
+++ b/xcalib.c
@@ -1089,14 +1089,14 @@ main (int argc, char *argv[])
   }
 
   if(!invert) {
-    /* ramps should be monotonic - otherwise content is nonsense! */
+    /* ramps should be increasing - otherwise content is nonsense! */
     for (i = 0; i < ramp_size - 1; i++) {
       if (r_ramp[i + 1] < r_ramp[i])
-        warning ("red gamma table not monotonic");
+        warning ("red gamma table not increasing");
       if (g_ramp[i + 1] < g_ramp[i])
-        warning ("green gamma table not monotonic");
+        warning ("green gamma table not increasing");
       if (b_ramp[i + 1] < b_ramp[i])
-        warning ("blue gamma table not monotonic");
+        warning ("blue gamma table not increasing");
     }
   } else {
     for (i = 0; i < ramp_size; i++) {

--- a/xcalib.c
+++ b/xcalib.c
@@ -1139,7 +1139,7 @@ main (int argc, char *argv[])
       }
       tmpRampVal = b_ramp[i];
     }
-    fprintf(stdout, "R: %d\tG: %d\t B: %d\t colors lost\n", ramp_size - r_res, ramp_size - g_res, ramp_size - b_res );
+    fprintf(stdout, "R: %d G: %d B: %d colors lost\n", ramp_size - r_res, ramp_size - g_res, ramp_size - b_res );
   }
 #ifdef _WIN32
   for (i = 0; i < ramp_size; i++) {

--- a/xcalib.c
+++ b/xcalib.c
@@ -1139,7 +1139,7 @@ main (int argc, char *argv[])
       }
       tmpRampVal = b_ramp[i];
     }
-    fprintf(stdout, "R: %d G: %d B: %d colors lost\n", ramp_size - r_res, ramp_size - g_res, ramp_size - b_res );
+    fprintf(stdout, "R: %d  G: %d  B: %d  colors lost\n", ramp_size - r_res, ramp_size - g_res, ramp_size - b_res );
   }
 #ifdef _WIN32
   for (i = 0; i < ramp_size; i++) {


### PR DESCRIPTION
Tab use (control character) was inconsistent and unnecessary, and causes warnings in plotutils, e.g.;
xcalib -p -a | grep ^[0-9] | graph -a -T X -x 0 3071 -y 0 65535 -m 0 -X "$(xcalib -l -a | tail -n 1)"