### PR TITLE
Fix incorrect use of X11 screen and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ where the available options are:
 
 * -display <host:dpy>     or -d
 * -screen <screen-#>      or -s
+* -output <output-#>      or -o
 * -clear                  or -c
 * -noaction <LUT-size>    or -n
 * -verbose                or -v
@@ -225,6 +226,8 @@ may be written in C++ to ease modularisation of the code and allow
 utilization by other software.
 
 ### history
+#### 0.10: 2018-01-10
+- Fix incorrect use of X11 screen and output
 #### 0.9: 2014-11-09
 - fix rounding errors from upsampling of gamma ramps
 - fix -printramps uses integers

--- a/xcalib.c
+++ b/xcalib.c
@@ -124,6 +124,7 @@ usage (void)
 #ifndef _WIN32
   fprintf (stdout, "    -display <host:dpy>     or -d\n");
   fprintf (stdout, "    -screen <screen-#>      or -s\n");
+  fprintf (stdout, "    -output <output-#>      or -o\n");
 #else
   fprintf (stdout, "    -screen <monitor-#>     or -s\n");
 #endif
@@ -560,6 +561,7 @@ main (int argc, char *argv[])
   XF86VidModeGamma gamma;
   Display *dpy = NULL;
   char *displayname = NULL;
+  int xoutput = 0;
 #ifdef FGLRX
   int controller = -1;
   FGLRX_X11Gamma_C16native fglrx_gammaramps;
@@ -626,6 +628,15 @@ main (int argc, char *argv[])
       screen = atoi (argv[i]);
       continue;
     }
+#ifndef _WIN32
+    /* X11 output */
+    if (!strcmp (argv[i], "-o") || !strcmp (argv[i], "-output")) {
+      if (++i >= argc)
+        usage ();
+        xoutput = atoi (argv[i]);
+        continue;
+    }
+#endif
 #ifdef FGLRX
     /* ATI controller index (for FGLRX only) */
     if (!strcmp (argv[i], "-x") || !strcmp (argv[i], "-controller")) {
@@ -869,7 +880,7 @@ main (int argc, char *argv[])
   int major_versionp = 0;
   int minor_versionp = 0;
   int n = 0;
-  Window root = RootWindow(dpy, DefaultScreen( dpy )); 
+  Window root = RootWindow(dpy, screen);
 
   XRRQueryVersion( dpy, &major_versionp, &minor_versionp );
   xrr_version = major_versionp*100 + minor_versionp;
@@ -886,7 +897,7 @@ main (int argc, char *argv[])
       XRROutputInfo * output_info = XRRGetOutputInfo( dpy, res,
                                                         output);
       if(output_info->crtc)
-        if(ncrtc++ == screen)
+        if(ncrtc++ == xoutput)
         {
           crtc = output_info->crtc;
           ramp_size = XRRGetCrtcGammaSize( dpy, crtc );


### PR DESCRIPTION
There is a bug when xcalib is used with an X11 server configured in
ZaphodHead mode (where each physical display is a seperate X11 screen).
The second display cannot be selected with either:

	./xcalib -d :0.1 gamma_1_0.icc
	./xcalib -d :0 -s 1 gamma_1_0.icc

This is because a display's default screen is always selected and the
screen argument is incorrectly used to select the controller.

The patch uses the screen argument to correctly select and X11 screen
and adds an output argument to select which controller to use. This is
the same behaviour as the xrandr program.

Outputs can now be selected with:

	./xcalib -d :0.0 -o 1 gamma_1_0.icc
	./xcalib -d :0 -s 0 -o 1 gamma_1_0.icc

Screens (in ZaphodHead mode) can now be selected with:

	./xcalib -d :0.1 gamma_1_0.icc
	./xcalib -d :0 -s 1 gamma_1_0.icc