### PR TITLE
install target removes executable bits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ win_xcalib: xcalib.c
 	$(CC) $(CFLAGS) -mwindows -lm resource.o -o xcalib xcalib.o
 
 install:
-	cp -pv ./xcalib $(DESTDIR)/usr/local/bin/
+	cp ./xcalib $(DESTDIR)/usr/local/bin/
+	chown root:root $(DESTDIR)/usr/local/bin/xcalib
 #	chmod 0755 $(DESTDIR)/usr/local/bin/xcalib
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ win_xcalib: xcalib.c
 	$(CC) $(CFLAGS) -mwindows -lm resource.o -o xcalib xcalib.o
 
 install:
-	cp ./xcalib $(DESTDIR)/usr/local/bin/
-	chmod 0644 $(DESTDIR)/usr/local/bin/xcalib
+	cp -pv ./xcalib $(DESTDIR)/usr/local/bin/
+#	chmod 0755 $(DESTDIR)/usr/local/bin/xcalib
 
 clean:
 	rm -f xcalib.o


### PR DESCRIPTION
the execute bits ( rwxr-xr-x ) are set by default when xcalib is compiled. the file copy will also have them set. either skip the chmod entirely or uncomment the line to ensure no setgid nor setuid bits are set.