### PR TITLE
Add -outputname/-O option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This program is GPL-licensed **postcardware!** More infos at end of README.
 This program comes with ABSOLUTELY NO WARRANTY! Use on your own risk.
 
 ### purpose
-load 'vcgt'-tag of ICC profiles to X-server like MS-Windows or MacOS 
+load 'vcgt'-tag of ICC profiles to X-server like MS-Windows or MacOS
 do it to calibrate your display.
 Versions 0.5 and higher are also usable with Microsoft Windows. They
 can be used as a free alternative to other calibration loaders.
@@ -59,13 +59,13 @@ bright.
 
 The values that shouldn't alter the screen for gamma, brightness and
 contrast are gamma=1.0 brightness=0.0 and contrast=100.0 .
-  
+
 ### requirements
 #### LINUX/UNIXes
-  
+
 This program is intended for X11-Servers like XFree86 that come with
 XVidModeExtension (e.g. XFree86 4.x.x) and XRandR. Make sure that the
-extension is available. Other X-servers like OpenWin do not contain 
+extension is available. Other X-servers like OpenWin do not contain
 XVidMode stuff - so please don't ask me for support if XVidMode isn't
 supported. If you are experiencing problems with the X.org server
 because of missing XVidMode header files, search for the additional
@@ -77,9 +77,9 @@ X11 driver was added. The libs and header files are provided but may
 need to be updated for the most current video cards.
 The X11 and XVidMode headers are still required.
 Thanks to bleader who sent me a patch for multi-monitor support
-  
+
 #### Microsoft Windows
- 
+
 Since version 0.5, Win32-support was added. The program will work
 with most video cards, that have correctly implemented drivers. You
 need a working C compiler with the right windows headers to rebuild
@@ -106,13 +106,13 @@ following commands should lead you to a working version of xcalib:
     $ make xcalib
     $ make win\_xcalib
     $ make fglrx\_xcalib
-  
+
 For most UNIX-based systems the default version of xcalib should
 work. It only uses the XVidMode-Extension. The following command
 creates the executable:
 
     $ make xcalib
-  
+
 The Win32 version was made with and tested for MinGW. Since most
 users do not have a running MinGW environment, a binary executable is
 provided. To compile it on your own, the following command creates a
@@ -152,13 +152,13 @@ to - this is the calibrated state.
 Calibration linearizes your device, helps to set characteristics and
 can be easily repeated. Repeating calibration can help you to keep
 your profile constant (users don't need to change it).
-  
+
 The current way of embedding calibration data in a profile is against
-the theory of separating calibration from profiling - but we have to 
+the theory of separating calibration from profiling - but we have to
 live with it since it's common. They use a tag called Video Card
 Gamma Tag (or vcgt) in ICC-profiles that contains calibration values.
 The calibration is applied before profile creation, where the vcgt
-  
+
 will be saved in your profile for convenience reasons: All color
 settings for the display device are stored in a common file.
 
@@ -182,8 +182,8 @@ using a tool like AdobeGamme oder xcalib. This may leed to
 posterization artifacts on your display (but doesn't affect
 printouts). You should tweak your monitor for perfect linearization
 as much as possible - the remaining tweaks might be part of a
-profile (, the "vcgt" tag). 
-  
+profile (, the "vcgt" tag).
+
 If you want to come around that drawback: bug your video card vendor
 and ask for >8bit LUTs (plus LUTs for every output connector).
 
@@ -216,7 +216,7 @@ On Win32-systems, some drivers are not correctly implemented. E.g.
 the NVidia Riva driver for Windows2000 and WindowsXP wrote nonsense
 values to the video cards RAMDAC (resulting in a gray display). I
 used for these cards an old NT-driver from a video card vendor.
-  
+
 The source code became messy in the last time because of numerous
 workarounds and a bad mixture of Win32, X11, ATI code and code for
 the different parsers used to get the gamma ramps from the profile.
@@ -240,7 +240,7 @@ utilization by other software.
   linear interpolation is used for creating the values in between
 - changed -n parameter: now the size of the simulated LUT must
   be given after -n/-noaction paramter
-      
+
 #### 0.7: 2007-06-23
 - major code-cleanup
 - fixed gamma limits for vcg-formulae
@@ -266,7 +266,7 @@ utilization by other software.
 - added loss calculation (option "-loss" or "-l") which shows how
   many steps are lost by calibrating the device
 - added limits of VideoCardGammaFormula to internal parser
-    
+
 #### 0.5: 2005-03-03
 - Win32 version added (compilable with MinGW)
   + support for command line options as usual
@@ -283,7 +283,7 @@ utilization by other software.
   locations for X11 and patched lcms libs and headers
 - beautified code for better readability
 - added sample profile which contains a vcg-table
-      
+
 #### 0.4: 2005-01-30
 - own implementation for parsing the vcgt tags added.
 - switch to lcms-1.13 (patched) instead of icclib
@@ -295,7 +295,7 @@ utilization by other software.
   the ability to use it and to make xcalib's code less confuscating
   apply the bundled patch to LCMS
 - minor README changes to ease readability
-    
+
 #### 0.3:
 - raise error if no vcg-tag available
 - profile no more a necessary parameter after -c and -h option

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ where the available options are:
 * -display <host:dpy>     or -d
 * -screen <screen-#>      or -s
 * -output <output-#>      or -o
+* -outputname <name>      or -O
 * -clear                  or -c
 * -noaction <LUT-size>    or -n
 * -verbose                or -v

--- a/xcalib.c
+++ b/xcalib.c
@@ -152,7 +152,7 @@ usage (void)
   fprintf (stdout,
 	   "last parameter must be an ICC profile containing a vcgt-tag\n");
   fprintf (stdout, "\n");
-#ifndef _WIN32 
+#ifndef _WIN32
   fprintf (stdout, "Example: ./xcalib -d :0 -s 0 -v bluish.icc\n");
 #else
   fprintf (stdout, "Example: ./xcalib -v bluish.icc\n");
@@ -182,14 +182,14 @@ static HDC monitorDC = 0;
 BOOL CALLBACK MonitorEnumProc (HMONITOR monitor, HDC hdc, LPRECT rect, LPARAM data)
 {
   MONITORINFOEX monitorInfo;
-  
+
   if(monitorSearchIndex++ != (unsigned int)data)
     return TRUE; /* continue enumeration */
-  
+
   monitorInfo.cbSize = sizeof(monitorInfo);
   if(GetMonitorInfo(monitor, (LPMONITORINFO)&monitorInfo) )
     monitorDC = CreateDC(NULL, monitorInfo.szDevice, NULL, NULL);
-  
+
   return FALSE;  /* stop enumeration */
 }
 
@@ -220,24 +220,24 @@ float        LinInterpolateRampU16   ( unsigned short    * ramp,
 {
   unsigned short val1, val2;
   float start, dist, result;
-  
+
   if(!ramp)
     return 0.0;
-  
+
   if(pos < 0)
     return ramp[0];
-    
+
   if(pos > ramp_size-1)
     return ramp[ramp_size-1];
-  
+
   dist = modff( pos, &start );
   val1 = ramp[(int)start];
   val2 = ramp[(int)start+1];
-    
+
   result = val2 - val1;
   result *= dist;
   result += val1;
-    
+
   return result;
 }
 
@@ -298,7 +298,7 @@ read_vcgt_internal(const char * filename, u_int16_t * rRamp, u_int16_t * gRamp,
     bytesRead = fread(cTmp, 1, 4, fp);
     tagName = BE_INT(cTmp);
     bytesRead = fread(cTmp, 1, 4, fp);
-    tagOffset = BE_INT(cTmp); 
+    tagOffset = BE_INT(cTmp);
     bytesRead = fread(cTmp, 1, 4, fp);
     tagSize = BE_INT(cTmp);
     if(!bytesRead)
@@ -411,7 +411,7 @@ read_vcgt_internal(const char * filename, u_int16_t * rRamp, u_int16_t * gRamp,
         {
           rRamp[j] = 65536.0 *
             ((double) pow ((double) j / (double) (nEntries),
-                           rGamma * (double) xcalib_state.gamma_cor 
+                           rGamma * (double) xcalib_state.gamma_cor
                           ) * (rMax - rMin) + rMin);
           gRamp[j] = 65536.0 *
             ((double) pow ((double) j / (double) (nEntries),
@@ -445,7 +445,7 @@ read_vcgt_internal(const char * filename, u_int16_t * rRamp, u_int16_t * gRamp,
         message ("entry size:      \t%dbits\n",entrySize  * 8);
         message ("entries/channel: \t%d\n", numEntries);
         message ("tag size:        \t%d\n", tagSize);
-                                                
+
         if(numChannels!=3)          /* assume we have always RGB */
           break;
 
@@ -520,7 +520,7 @@ read_vcgt_internal(const char * filename, u_int16_t * rRamp, u_int16_t * gRamp,
           retVal = -1;
           break;
         }
-        
+
         if(numEntries >= nEntries) {
           /* simply subsample if the LUT is smaller than the number of entries in the file */
           ratio = (unsigned int)(numEntries / (nEntries));
@@ -536,15 +536,15 @@ read_vcgt_internal(const char * filename, u_int16_t * rRamp, u_int16_t * gRamp,
           redRamp[numEntries] = (redRamp[numEntries-1] + (redRamp[numEntries-1] - redRamp[numEntries-2])) & 0xffff;
           if(redRamp[numEntries] < 0x4000)
             redRamp[numEntries] = 0xffff;
-          
+
           greenRamp[numEntries] = (greenRamp[numEntries-1] + (greenRamp[numEntries-1] - greenRamp[numEntries-2])) & 0xffff;
           if(greenRamp[numEntries] < 0x4000)
             greenRamp[numEntries] = 0xffff;
-          
+
           blueRamp[numEntries] = (blueRamp[numEntries-1] + (blueRamp[numEntries-1] - blueRamp[numEntries-2])) & 0xffff;
           if(blueRamp[numEntries] < 0x4000)
             blueRamp[numEntries] = 0xffff;
-         
+
           for(j=0; j<numEntries; j++) {
             for(i=0; i<ratio; i++)
             {
@@ -607,7 +607,7 @@ main (int argc, char *argv[])
     WORD  Red[256];
     WORD  Green[256];
     WORD  Blue[256];
-  } GAMMARAMP; 
+  } GAMMARAMP;
   GAMMARAMP winGammaRamp;
   HDC hDc = NULL;
 #endif
@@ -624,7 +624,7 @@ main (int argc, char *argv[])
 #endif
 
   /* command line parsing */
-  
+
 #ifndef _WIN32
   if (argc < 2)
     usage ();
@@ -737,7 +737,7 @@ main (int argc, char *argv[])
       xcalib_state.redMin = xcalib_state.greenMin = xcalib_state.blueMin = brightness / 100.0;
       xcalib_state.redMax = xcalib_state.greenMax = xcalib_state.blueMax =
         (1.0 - xcalib_state.blueMin) * xcalib_state.blueMax + xcalib_state.blueMin;
-      
+
       correction = 1;
       continue;
     }
@@ -755,11 +755,11 @@ main (int argc, char *argv[])
       xcalib_state.redMax = xcalib_state.greenMax = xcalib_state.blueMax = contrast / 100.0;
       xcalib_state.redMax = xcalib_state.greenMax = xcalib_state.blueMax =
         (1.0 - xcalib_state.blueMin) * xcalib_state.blueMax + xcalib_state.blueMin;
- 
+
       correction = 1;
       continue;
     }
-    /* additional red calibration */ 
+    /* additional red calibration */
     if (!strcmp (argv[i], "-red")) {
       double gamma = 1.0, brightness = 0.0, contrast = 100.0;
       if (++i >= argc)
@@ -786,12 +786,12 @@ main (int argc, char *argv[])
         warning("contrast is out of range 1.0-100.0");
         continue;
       }
- 
+
       xcalib_state.redMin = brightness / 100.0;
       xcalib_state.redMax =
         (1.0 - xcalib_state.redMin) * (contrast / 100.0) + xcalib_state.redMin;
       xcalib_state.redGamma = gamma;
- 
+
       correction = 1;
       continue;
     }
@@ -822,12 +822,12 @@ main (int argc, char *argv[])
         warning("contrast is out of range 1.0-100.0");
         continue;
       }
- 
+
       xcalib_state.greenMin = brightness / 100.0;
       xcalib_state.greenMax =
         (1.0 - xcalib_state.greenMin) * (contrast / 100.0) + xcalib_state.greenMin;
       xcalib_state.greenGamma = gamma;
- 
+
       correction = 1;
       continue;
     }
@@ -858,16 +858,16 @@ main (int argc, char *argv[])
         warning("contrast is out of range 1.0-100.0");
         continue;
       }
- 
+
       xcalib_state.blueMin = brightness / 100.0;
       xcalib_state.blueMax =
         (1.0 - xcalib_state.blueMin) * (contrast / 100.0) + xcalib_state.blueMin;
       xcalib_state.blueGamma = gamma;
- 
+
       correction = 1;
       continue;
     }
- 
+
     if (i != argc - 1 && !clear && i) {
       usage ();
     }
@@ -920,7 +920,7 @@ main (int argc, char *argv[])
   xrr_version = major_versionp*100 + minor_versionp;
 
   if(xrr_version >= 102)
-  {                           
+  {
     XRRScreenResources * res = XRRGetScreenResources( dpy, root );
     int ncrtc = 0;
 
@@ -977,7 +977,7 @@ main (int argc, char *argv[])
     }
     goto cleanupX;
   }
-  
+
   /* get number of entries for gamma ramps */
   if(!donothing)
   {
@@ -1027,7 +1027,7 @@ main (int argc, char *argv[])
     default:
       error("unsupported ramp size %u", ramp_size);
   }
-  
+
   r_ramp = (unsigned short *) malloc (ramp_size * sizeof (unsigned short));
   g_ramp = (unsigned short *) malloc (ramp_size * sizeof (unsigned short));
   b_ramp = (unsigned short *) malloc (ramp_size * sizeof (unsigned short));
@@ -1081,7 +1081,7 @@ main (int argc, char *argv[])
     redMin = (double)r_ramp[0] / 65535.0;
     redMax = (double)r_ramp[ramp_size - 1] / 65535.0;
     redBrightness = redMin * 100.0;
-    redContrast = (redMax - redMin) / (1.0 - redMin) * 100.0; 
+    redContrast = (redMax - redMin) / (1.0 - redMin) * 100.0;
     message("Red Brightness: %f   Contrast: %f  Max: %f  Min: %f\n", redBrightness, redContrast, redMax, redMin);
   }
 
@@ -1094,7 +1094,7 @@ main (int argc, char *argv[])
     greenMin = (double)g_ramp[0] / 65535.0;
     greenMax = (double)g_ramp[ramp_size - 1] / 65535.0;
     greenBrightness = greenMin * 100.0;
-    greenContrast = (greenMax - greenMin) / (1.0 - greenMin) * 100.0; 
+    greenContrast = (greenMax - greenMin) / (1.0 - greenMin) * 100.0;
     message("Green Brightness: %f   Contrast: %f  Max: %f  Min: %f\n", greenBrightness, greenContrast, greenMax, greenMin);
   }
 
@@ -1107,7 +1107,7 @@ main (int argc, char *argv[])
     blueMin = (double)b_ramp[0] / 65535.0;
     blueMax = (double)b_ramp[ramp_size - 1] / 65535.0;
     blueBrightness = blueMin * 100.0;
-    blueContrast = (blueMax - blueMin) / (1.0 - blueMin) * 100.0; 
+    blueContrast = (blueMax - blueMin) / (1.0 - blueMin) * 100.0;
     message("Blue Brightness: %f   Contrast: %f  Max: %f  Min: %f\n", blueBrightness, blueContrast, blueMax, blueMin);
   }
 
@@ -1123,7 +1123,7 @@ main (int argc, char *argv[])
                   ) * (xcalib_state.greenMax - xcalib_state.greenMin)) + xcalib_state.greenMin);
       b_ramp[i] =  65536.0 * (((double) pow (((double) b_ramp[i]/65536.0),
                                 xcalib_state.blueGamma * (double) xcalib_state.gamma_cor
-                  ) * (xcalib_state.blueMax - xcalib_state.blueMin)) + xcalib_state.blueMin); 
+                  ) * (xcalib_state.blueMax - xcalib_state.blueMin)) + xcalib_state.blueMin);
     }
     message("Altering Red LUTs with   Gamma %f   Min %f   Max %f\n",
        xcalib_state.redGamma, xcalib_state.redMin, xcalib_state.redMax);
@@ -1194,7 +1194,7 @@ main (int argc, char *argv[])
   }
 
 #endif
- 
+
   if(printramps)
     for(i=0; i<ramp_size; i++)
       fprintf(stdout,"%d %d %d\n", r_ramp[i], g_ramp[i], b_ramp[i]);

--- a/xcalib.c
+++ b/xcalib.c
@@ -651,8 +651,8 @@ main (int argc, char *argv[])
     if (!strcmp (argv[i], "-d") || !strcmp (argv[i], "-display")) {
       if (++i >= argc)
         usage ();
-        displayname = argv[i];
-        continue;
+      displayname = argv[i];
+      continue;
     }
 #endif
     /* X11 screen / Win32 monitor index */
@@ -667,8 +667,8 @@ main (int argc, char *argv[])
     if (!strcmp (argv[i], "-o") || !strcmp (argv[i], "-output")) {
       if (++i >= argc)
         usage ();
-        xoutput = atoi (argv[i]);
-        continue;
+      xoutput = atoi (argv[i]);
+      continue;
     }
 #endif
 #ifdef FGLRX

--- a/xcalib.c
+++ b/xcalib.c
@@ -570,8 +570,6 @@ int
 main (int argc, char *argv[])
 {
   char in_name[256] = { '\000' };
-  char tag_name[40] = { '\000' };
-  int found;
   u_int16_t *r_ramp = NULL, *g_ramp = NULL, *b_ramp = NULL;
   int i;
   int clear = 0;


### PR DESCRIPTION
This is useful when you want to change the settings for a particular monitor (e.g. "eDP-1") and don't know which other monitors are plugged in, or in what order they will be numbered.