### PR TITLE
Fixes #15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@
 # if it doesn't compile right-out-of-the-box, it may be sufficient
 # to change the following variables
 
-XCALIB_VERSION = 0.10
+XCALIB_VERSION = 0.11
 CFLAGS = -O2
 XINCLUDEDIR = /usr/X11R6/include
 XLIBDIR = /usr/X11R6/lib

--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ may be written in C++ to ease modularization of the code and allow
 utilization by other software.
 
 ### history
+#### 0.11: 2023-10-07
+- allow flicker-free chaining of `-c` with `-a` ...
+
 #### 0.10: 2018-01-10
 - Fix incorrect use of X11 screen and output; rename -s to -o option
 
@@ -388,6 +391,6 @@ program, send me a picture postcard from your country/area to:
     GERMANY
 
 Please write on it your name and email-address and that you use
-xcalib-0.8 .
+xcalib-0.11 .
 
 EOF

--- a/resource.rc
+++ b/resource.rc
@@ -2,8 +2,8 @@ LANGUAGE 0, 0
 100 ICON  icon.ico
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,9,0,0
- PRODUCTVERSION 0,9,0,0
+ FILEVERSION 0,11,0,0
+ PRODUCTVERSION 0,11,0,0
 #ifdef _DEBUG
  FILEFLAGS 0x1L
 #else
@@ -21,7 +21,7 @@ BEGIN
       VALUE "FileDescription", "xcalib\0"
       VALUE "LegalCopyright", "Copyright (c) 2004-2007 Stefan Doehla\0"
       VALUE "OriginalFilename", "xcalib.exe\0"
-      VALUE "ProductVersion", "0,9\0"
+      VALUE "ProductVersion", "0,11\0"
     END
   END
   BLOCK "VarFileInfo"

--- a/xcalib.c
+++ b/xcalib.c
@@ -947,7 +947,8 @@ main (int argc, char *argv[])
   gamma.red = 1.0;
   gamma.green = 1.0;
   gamma.blue = 1.0;
-  if (clear) {
+  // "&& !alter" allows flicker-free chaining of -c with -a ...
+  if (clear && !alter) {
 #ifndef FGLRX
     if(xrr_version >= 102)
     {
@@ -1048,14 +1049,21 @@ main (int argc, char *argv[])
 #ifndef _WIN32
     if (xrr_version >= 102)
     {
-      XRRCrtcGamma * gamma = 0;
-      if((gamma = XRRGetCrtcGamma(dpy, crtc)) == 0 )
-        warning ("XRRGetCrtcGamma() is unable to get display calibration");
+      if( clear ){
+        for( i = 0; i < ramp_size; i++ )
+          // same as "clear" above
+          r_ramp[i] = g_ramp[i] = b_ramp[i] = i * 65535 / ramp_size;
+      }
+      else {
+        XRRCrtcGamma * gamma = 0;
+        if((gamma = XRRGetCrtcGamma(dpy, crtc)) == 0 )
+          warning ("XRRGetCrtcGamma() is unable to get display calibration");
 
-      for (i = 0; i < ramp_size; i++) {
-        r_ramp[i] = gamma->red[i];
-        g_ramp[i] = gamma->green[i];
-        b_ramp[i] = gamma->blue[i];
+        for (i = 0; i < ramp_size; i++) {
+          r_ramp[i] = gamma->red[i];
+          g_ramp[i] = gamma->green[i];
+          b_ramp[i] = gamma->blue[i];
+        }
       }
     }
     else if (!XF86VidModeGetGammaRamp (dpy, screen, ramp_size, r_ramp, g_ramp, b_ramp))


### PR DESCRIPTION
See #15 for description of the issue.

The simplest solution seemed to be to allow to combine `-c` (clear) with other `-a` (alter) arguments in a flicker-free manner.

Because this adds new functionality by extending the semantics of argument interaction (without introducing any new nor removing any arguments though), I have bumped `xcalib` version to proliferate into all repositories.